### PR TITLE
add option for standarizing mapped value

### DIFF
--- a/src/choropleth.js
+++ b/src/choropleth.js
@@ -9,6 +9,7 @@ L.choropleth = module.exports = function(geojson, opts) {
 	// Set default options in case any weren't passed
 	_.defaults(opts, {
 		valueProperty: 'value',
+        normProperty: false,
 		scale: ['white', 'red'],
 		steps: 5,
 		mode: 'q'
@@ -19,7 +20,13 @@ L.choropleth = module.exports = function(geojson, opts) {
 	
 	// Calculate limits
 	var values = geojson.features.map(function(item) {
-		return item.properties[opts.valueProperty]
+        // if use supplies a normalizing value then caclculate new value
+        if(opts.normProperty){
+           return item.properties[opts.valueProperty]/item.properties[opts.normProperty];
+        } else {
+           return item.properties[opts.valueProperty]; 
+        }
+		
 	})
 	var limits = chroma.limits(values, opts.mode, opts.steps - 1)
 	
@@ -29,11 +36,17 @@ L.choropleth = module.exports = function(geojson, opts) {
 	return L.geoJson(geojson, _.extend(opts, {
 		style: function(feature) {
 			var style = {}
-			
+            
+            // same as above
+			if(opts.normProperty) {
+                var value = feature.properties[opts.valueProperty]/feature.properties[opts.normProperty];
+            } else {
+                var value = feature.properties[opts.valueProperty];
+            }
 			if(feature.properties[opts.valueProperty]) {
 				// Find the bucket/step/limit that this value is less than and give it that color
 				for(var i = 0; i < limits.length; i++) {
-					if(feature.properties[opts.valueProperty] <= limits[i]) {
+					if(value <= limits[i]) {
 						style.fillColor = colors[i]
 						break
 					}


### PR DESCRIPTION
Provide an option for the user to supply a value by which to standardize (or normalize) the valueProperty being used to create the choropleth (such as population or land area). Allows for a more honest comparison of raw counts. See [Standardizing Data](http://axismaps.github.io/thematic-cartography/articles/standardize.html).
