### PR TITLE
Don't write into user's style object

### DIFF
--- a/src/choropleth.js
+++ b/src/choropleth.js
@@ -58,9 +58,9 @@ L.choropleth = module.exports = function (geojson, opts) {
       // Return this style, but include the user-defined style if it was passed
       switch (typeof userStyle) {
         case 'function':
-          return _.extend(userStyle(), style)
+          return _.defaults(style, userStyle(feature))
         case 'object':
-          return _.extend(userStyle, style)
+          return _.defaults(style, userStyle)
         default:
           return style
       }

--- a/test/choropleth.test.js
+++ b/test/choropleth.test.js
@@ -10,7 +10,9 @@ describe('basic usage', function () {
 
   before(function () {
     this.choropleth = require('../src/choropleth')
+    this.style = {fillColor: 'lime'}
     this.layer = this.choropleth(geojson, {
+      style: this.style,
       valueProperty: 'incidents'
     })
     // console.log(require('util').inspect(this.layer.options, {colors: true, depth: 2}))
@@ -43,6 +45,10 @@ describe('basic usage', function () {
   it('sets the color of a feature', function () {
     var style = this.layer.options.style(geojson.features[0])
     style.should.have.property('fillColor', '#ffbfbf')
+  })
+
+  it("doesn't modify style object", function () {
+    this.style.should.be.eql({fillColor: 'lime'})
   })
 })
 

--- a/test/choropleth.test.js
+++ b/test/choropleth.test.js
@@ -23,23 +23,19 @@ describe('basic usage', function () {
   })
 
   it('sets limits', function () {
-    this.layer.options.should.have.property('limits', [
-      814,
-      18597.5,
-      26984,
-      36140.5,
-      45529
-    ])
+    this.layer.options.should.have.property('limits')
+    var limits = this.layer.options.limits
+    limits.should.have.length(5)
+    limits[0].should.be.equal(814)
+    limits[4].should.be.equal(45529)
   })
 
   it('sets colors', function () {
-    this.layer.options.should.have.property('colors', [
-      '#ffffff',
-      '#ffbfbf',
-      '#ff7f7f',
-      '#ff3f3f',
-      '#ff0000'
-    ])
+    this.layer.options.should.have.property('colors')
+    var colors = this.layer.options.colors
+    colors.should.have.length(5)
+    colors[0].should.be.equal('#ffffff')
+    colors[4].should.be.equal('#ff0000')
   })
 
   it('sets the color of a feature', function () {
@@ -66,13 +62,11 @@ describe('valueProperty function', function () {
   })
 
   it('sets limits', function () {
-    this.layer.options.limits.should.eql([
-      814,
-      18597.5,
-      26984,
-      36140.5,
-      45529
-    ])
+    this.layer.options.should.have.property('limits')
+    var limits = this.layer.options.limits
+    limits.should.have.length(5)
+    limits[0].should.be.equal(814)
+    limits[4].should.be.equal(45529)
   })
 
   it('sets the color of a feature', function () {


### PR DESCRIPTION
Allows for e.g. setting default fillColor for NaN values with simple:

    ...
    style: {
        fillColor: 'transparent',
        ...
    }

The previous implementation would overwrite the default style object, e.g. making NaN-valued layers filled with the color of the previously added layer.

Closes https://github.com/timwis/leaflet-choropleth/issues/19